### PR TITLE
Fix config path handling. Use absolute paths for scheduled tasks.

### DIFF
--- a/src/jira_backup/_backup.py
+++ b/src/jira_backup/_backup.py
@@ -515,7 +515,7 @@ def main() -> None:
                 time_hour=hour,
                 time_minute=minute,
                 service_type=args.schedule_service,
-                config_path=config_path,
+                config_path=config_path.resolve(),
             )
             print("-> Scheduled task setup completed")
             exit(0)

--- a/src/jira_backup/_backup.py
+++ b/src/jira_backup/_backup.py
@@ -2,9 +2,11 @@ import argparse
 import json
 import os
 import platform
+import shlex
 import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Dict, Any, Literal
 
 import boto3
@@ -299,50 +301,55 @@ class Atlassian:
 
 
 def setup_scheduled_task(
+    *,
     frequency_days: int = 4,
     time_hour: int = 10,
     time_minute: int = 0,
     service_type: Literal["jira", "confluence"] = "jira",
+    config_path: Path,
 ) -> bool:
-    script_path = os.path.abspath(__file__)
-    script_dir = os.path.dirname(script_path)
-
     system = platform.system().lower()
 
     if system in ["linux", "darwin"]:
         return setup_cron_task(
-            script_path,
-            script_dir,
-            frequency_days,
-            time_hour,
-            time_minute,
-            service_type,
+            frequency_days=frequency_days,
+            time_hour=time_hour,
+            time_minute=time_minute,
+            service_type=service_type,
+            config_path=config_path,
         )
     elif system == "windows":
         return setup_windows_task(
-            script_path,
-            script_dir,
-            frequency_days,
-            time_hour,
-            time_minute,
-            service_type,
+            frequency_days=frequency_days,
+            time_hour=time_hour,
+            time_minute=time_minute,
+            service_type=service_type,
+            config_path=config_path,
         )
     else:
         raise Exception(f"Unsupported operating system: {system}")
 
 
 def setup_cron_task(
-    script_path: os.PathLike[str] | str,
-    script_dir: os.PathLike[str] | str,
+    *,
     frequency_days: int,
     time_hour: int,
     time_minute: int,
     service_type: Literal["jira", "confluence"],
+    config_path: Path,
 ) -> bool:
-    python_path = sys.executable
     service_flag = "-j" if service_type == "jira" else "-c"
-
-    cron_command = f"{time_minute} {time_hour} */{frequency_days} * * cd {script_dir} && {python_path} {script_path} {service_flag}"
+    backup_command = shlex.join(
+        [
+            sys.executable,
+            "-m",
+            "jira_backup",
+            service_flag,
+            "-C",
+            config_path.as_posix(),
+        ]
+    )
+    cron_command = f"{time_minute} {time_hour} */{frequency_days} * * {backup_command}"
 
     try:
         result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
@@ -395,17 +402,18 @@ def setup_cron_task(
 
 
 def setup_windows_task(
-    script_path: os.PathLike[str] | str,
-    script_dir: os.PathLike[str] | str,
+    *,
     frequency_days: int,
     time_hour: int,
     time_minute: int,
     service_type: Literal["jira", "confluence"],
+    config_path: Path,
 ) -> bool:
-    python_path = sys.executable
-    service_flag = "-j" if service_type == "jira" else "-c"
     task_name = f"jira-backup-py-{service_type}"
-
+    service_flag = "-j" if service_type == "jira" else "-c"
+    backup_command = subprocess.list2cmdline(
+        [sys.executable, "-m", "jira_backup", service_flag, "-C", config_path]
+    )
     cmd = [
         "schtasks",
         "/create",
@@ -416,7 +424,7 @@ def setup_windows_task(
         "/mo",
         str(frequency_days),
         "/tr",
-        f'"{python_path}" "{script_path}" {service_flag}',
+        backup_command,
         "/st",
         f"{time_hour:02d}:{time_minute:02d}",
         "/f",
@@ -440,7 +448,11 @@ def setup_windows_task(
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-C", type=str, dest="config_file", default="", help="path to config file"
+        "-C",
+        type=str,
+        dest="config_file",
+        default="config.yaml",
+        help="path to config file",
     )
     parser.add_argument(
         "-w", action="store_true", dest="wizard", help="activate config wizard"
@@ -478,12 +490,12 @@ def main() -> None:
         help="service type for scheduled backup (default: jira)",
     )
     args = parser.parse_args()
-    # print('debug command-line: {}'.format(args))
+    config_path = Path(args.config_file)
 
     if args.wizard:
         from ._wizard import create_config
 
-        create_config()
+        create_config(config_path=config_path)
 
     if args.schedule:
         try:
@@ -494,11 +506,16 @@ def main() -> None:
             if not (0 <= hour <= 23) or not (0 <= minute <= 59):
                 raise ValueError("Invalid time format")
 
+            if not config_path.exists():
+                print("-> Error: Can't schedule script without a config file.")
+                exit(1)
+
             setup_scheduled_task(
                 frequency_days=args.schedule_days,
                 time_hour=hour,
                 time_minute=minute,
                 service_type=args.schedule_service,
+                config_path=config_path,
             )
             print("-> Scheduled task setup completed")
             exit(0)
@@ -509,7 +526,7 @@ def main() -> None:
             print(f"-> Error setting up scheduled task: {e}")
             exit(1)
 
-    config = read_config(args.config_file)
+    config = read_config(config_path=config_path)
 
     if config["HOST_URL"] == "something.atlassian.net":
         raise ValueError(
@@ -551,7 +568,3 @@ def main() -> None:
         and config["UPLOAD_TO_AZURE"].get("AZURE_CONTAINER", "") != ""
     ):
         atlass.stream_to_azure(backup_url, file_name)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/jira_backup/_config.py
+++ b/src/jira_backup/_config.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import TypedDict, NotRequired
 
 import yaml
@@ -46,9 +46,6 @@ class Config(TypedDict):
     CUSTOM_FILENAME: NotRequired[ConfigCustomFilename]
 
 
-def read_config(path: os.PathLike[str] | str = "") -> Config:
-    if path == "":
-        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.yaml")
-    with open(path, "r") as config_file:
-        # TODO: Validate the loaded config before returning.
-        return yaml.full_load(config_file)  # type: ignore[no-any-return]
+def read_config(*, config_path: Path) -> Config:
+    # TODO: Validate the loaded config before returning.
+    return yaml.safe_load(config_path.read_text())  # type: ignore[no-any-return]

--- a/src/jira_backup/_wizard.py
+++ b/src/jira_backup/_wizard.py
@@ -1,11 +1,11 @@
-import os
+from pathlib import Path
 
 import yaml
 
 from ._config import ConfigUploadToS3, Config
 
 
-def create_config() -> None:
+def create_config(*, config_path: Path) -> None:
     custom_config = Config(
         HOST_URL=input("What is your Jira host name? "),
         USER_EMAIL=input("What is your Jira account email address? "),
@@ -27,10 +27,7 @@ def create_config() -> None:
             AWS_IS_SECURE=input_boolean("Do you want to use SSL?"),
         )
 
-    config_path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "config.yaml"
-    )
-    with open(config_path, "w+") as config_file:
+    with config_path.open("w+") as config_file:
         yaml.dump(custom_config, config_file, default_flow_style=False)
 
 

--- a/src/jira_backup/_wizard.py
+++ b/src/jira_backup/_wizard.py
@@ -27,7 +27,8 @@ def create_config(*, config_path: Path) -> None:
             AWS_IS_SECURE=input_boolean("Do you want to use SSL?"),
         )
 
-    with config_path.open("w+") as config_file:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with config_path.open("w", encoding="utf-8") as config_file:
         yaml.dump(custom_config, config_file, default_flow_style=False)
 
 


### PR DESCRIPTION
- No longer rely on the position of the library code in the file system (i.e., no more `__file__`).
- Default config path is now the `config.yaml` from the current working directory.
- Wizard, config loading, and scheduling all use the same explicit config path.
- Scheduled tasks now run `python -m jira_backup ... -C <resolved config path>`, so they work from any working directory.
- Config loading now uses `yaml.safe_load`.